### PR TITLE
Inclusion request: spdlog (for review only)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -35,8 +35,7 @@ class spdlogConan(ConanFile):
         cmake.definitions["SPDLOG_BUILD_TESTING"] = False
         cmake.configure()
         cmake.build()
-        cmake.install()
-        
+
     def package(self): 
         self.copy("*.h", dst="include", src=os.path.join(self.source_subfolder, "include"))
         self.copy(pattern="LICENSE", dst="licenses", src=self.source_subfolder)

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,11 +33,9 @@ class spdlogConan(ConanFile):
     
     def build(self):
         cmake = CMake(self)
-        definitions = {
-            "CMAKE_INSTALL_PREFIX": self.install_subfolder,
-            "SPDLOG_BUILD_TESTING": False
-        }
-        cmake.configure(defs=definitions)
+        cmake.definitions["CMAKE_INSTALL_PREFIX"] = self.install_subfolder
+        cmake.definitions["SPDLOG_BUILD_TESTING"] = False
+        cmake.configure()
         cmake.build()
         cmake.install()
         

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,7 +15,6 @@ class spdlogConan(ConanFile):
     exports = ["LICENSE.md"]
     exports_sources = ["CMakeLists.txt"]
     source_subfolder = "source_subfolder"
-    install_subfolder = "install_subfolder"
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"fmt_external": [True, False]}
@@ -33,14 +32,13 @@ class spdlogConan(ConanFile):
     
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["CMAKE_INSTALL_PREFIX"] = self.install_subfolder
         cmake.definitions["SPDLOG_BUILD_TESTING"] = False
         cmake.configure()
         cmake.build()
         cmake.install()
         
     def package(self): 
-        self.copy("*.h", dst="include", src=os.path.join(self.install_subfolder, "include"))
+        self.copy("*.h", dst="include", src=os.path.join(self.source_subfolder, "include"))
         self.copy(pattern="LICENSE", dst="licenses", src=self.source_subfolder)
 
     def package_info(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -30,8 +30,14 @@ class spdlogConan(ConanFile):
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self.source_subfolder)
 
+    def build(self):
+        cmake = CMake(self)
+        cmake.definitions["SPDLOG_BUILD_TESTING"] = False
+        cmake.configure()
+        cmake.build()
+        cmake.install()
+
     def package(self): 
-        self.copy("*.h", dst="include", src=os.path.join(self.source_subfolder, "include"))
         self.copy(pattern="LICENSE", dst="licenses", src=self.source_subfolder)
 
     def package_info(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,12 +29,6 @@ class spdlogConan(ConanFile):
         tools.get("{0}/archive/v{1}.tar.gz".format(source_url, self.version))
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self.source_subfolder)
-    
-    def build(self):
-        cmake = CMake(self)
-        cmake.definitions["SPDLOG_BUILD_TESTING"] = False
-        cmake.configure()
-        cmake.build()
 
     def package(self): 
         self.copy("*.h", dst="include", src=os.path.join(self.source_subfolder, "include"))

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,7 +18,7 @@ class spdlogConan(ConanFile):
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"fmt_external": [True, False]}
-    default_options = "fmt_external=False"
+    default_options = "fmt_external=True"
 
     def requirements(self):
         if self.options.fmt_external:
@@ -40,6 +40,8 @@ class spdlogConan(ConanFile):
         cmake.configure()
         cmake.install()
         self.copy(pattern="LICENSE", dst='licenses', src=self.source_subfolder)
+        self.copy(pattern="spdlogConfig*.cmake")
+        self.copy(pattern="spdlogConfig*.cmake", src=self.source_subfolder)
 
     def package_info(self):
         if self.options.fmt_external:

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,6 +15,7 @@ class spdlogConan(ConanFile):
     exports = ["LICENSE.md"]
     exports_sources = ["CMakeLists.txt"]
     source_subfolder = "source_subfolder"
+    install_subfolder = "install_subfolder"
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"fmt_external": [True, False]}
@@ -32,16 +33,17 @@ class spdlogConan(ConanFile):
     
     def build(self):
         cmake = CMake(self)
-        cmake.configure()
+        definitions = {
+            "CMAKE_INSTALL_PREFIX": self.install_subfolder,
+            "SPDLOG_BUILD_TESTING": False
+        }
+        cmake.configure(defs=definitions)
         cmake.build()
-        
-    def package(self):
-        cmake = CMake(self)
-        cmake.configure()
         cmake.install()
-        self.copy(pattern="LICENSE", dst='licenses', src=self.source_subfolder)
-        self.copy(pattern="spdlogConfig*.cmake")
-        self.copy(pattern="spdlogConfig*.cmake", src=self.source_subfolder)
+        
+    def package(self): 
+        self.copy("*.h", dst="include", src=os.path.join(self.install_subfolder, "include"))
+        self.copy(pattern="LICENSE", dst="licenses", src=self.source_subfolder)
 
     def package_info(self):
         if self.options.fmt_external:

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -8,6 +8,11 @@ conan_basic_setup()
 
 file(GLOB SOURCE_FILES *.cpp)
 
+#find_package(spdlog REQUIRED)
+
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+#target_link_libraries(${PROJECT_NAME} spdlog::spdlog ${CONAN_LIBS_FMT})
+
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -8,11 +8,7 @@ conan_basic_setup()
 
 file(GLOB SOURCE_FILES *.cpp)
 
-find_package(spdlog REQUIRED)
-
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-#target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-
-target_link_libraries(${PROJECT_NAME} spdlog::spdlog ${CONAN_LIBS_FMT})
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -8,11 +8,11 @@ conan_basic_setup()
 
 file(GLOB SOURCE_FILES *.cpp)
 
-#find_package(spdlog REQUIRED)
+find_package(spdlog REQUIRED)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+#target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 
-#target_link_libraries(${PROJECT_NAME} spdlog::spdlog ${CONAN_LIBS_FMT})
+target_link_libraries(${PROJECT_NAME} spdlog::spdlog ${CONAN_LIBS_FMT})
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -10,6 +10,6 @@ int main(int, char* [])
 	console->error("Some error message with arg{}..", 1);
 	console->warn("Easy padding in numbers like {:08d}", 12);
 #ifdef SPDLOG_FMT_EXTERNAL
-	fmt::print("The format library says the answer is {}", 42);
+	fmt::print("The format library says the answer is {}\n", 42);
 #endif
 }

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -1,6 +1,15 @@
 #include <spdlog/spdlog.h>
+#ifdef SPDLOG_FMT_EXTERNAL
+#include <fmt/format.h>
+#endif
 
 int main(int, char* [])
 {
 	auto console = spdlog::stdout_color_mt("console");
+	console->info("Welcome to spdlog!");
+	console->error("Some error message with arg{}..", 1);
+	console->warn("Easy padding in numbers like {:08d}", 12);
+#ifdef SPDLOG_FMT_EXTERNAL
+	fmt::print("The format library says the answer is {}", 42);
+#endif
 }


### PR DESCRIPTION
Fixes https://github.com/bincrafters/community/issues/159

- [x] Change default fmt_external=True
- [x] Copy "spdlogConfig*.cmake" to root of package
- [x] Add more output to test_package.cpp

This is the first time that I've come across this "`install()` in `package()`" thing.
```
    def package(self):
        cmake = CMake(self)
        cmake.configure()
        cmake.install()
        self.copy(pattern="LICENSE", dst='licenses', src=self.source_subfolder)
```
Is this documented somewhere?  I see how it works - CMake copies the install files into the `package` directory.  Cool.

Also, is the fact that Conan adds the root of each package to `CMAKE_MODULE_PATH` documented anywhere?

Per James' third bullet I updated `package()` to add:

        self.copy(pattern="spdlogConfig*.cmake")
        self.copy(pattern="spdlogConfig*.cmake", src=self.source_subfolder)

Then I temporarily changed `test_package/CMakeLists.txt` as follows to test:

```
find_package(spdlog REQUIRED)

add_executable(${PROJECT_NAME} ${SOURCE_FILES})
#target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

target_link_libraries(${PROJECT_NAME} spdlog::spdlog ${CONAN_LIBS_FMT})
```

And that worked.  However, looking at `spdlogConfig.cmake`, it has
```
set_target_properties(spdlog::spdlog PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES 
"/Users/eric/.conan/data/spdlog/0.16.3/bincrafters/testing/build/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/source_subfolder/include"
)
```

Notice that it is using the `build` directory, which happens to be in my local cache but if the package was pulled from server the `build` directory won't be there.  So I don't know how useful `spdlogConfig.cmake` is after all.

Thoughts? @memsharded @solvingj @SSE4 